### PR TITLE
Add web form to submit articles via GitHub Action

### DIFF
--- a/.github/workflows/process-article.yml
+++ b/.github/workflows/process-article.yml
@@ -1,0 +1,90 @@
+name: Process Article
+
+# Triggered by a repository_dispatch event sent from docs/submit.html
+# (or manually from the Actions tab via workflow_dispatch).
+on:
+  repository_dispatch:
+    types: [new-article]
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "Article URL to convert"
+        required: true
+        type: string
+      voice:
+        description: "Kokoro voice"
+        required: false
+        default: "af_bella"
+        type: string
+
+# Serialize runs so two submissions don't race on the git push.
+concurrency:
+  group: process-article
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve inputs
+        id: inputs
+        env:
+          DISPATCH_URL: ${{ github.event.client_payload.url }}
+          DISPATCH_VOICE: ${{ github.event.client_payload.voice }}
+          MANUAL_URL: ${{ github.event.inputs.url }}
+          MANUAL_VOICE: ${{ github.event.inputs.voice }}
+        run: |
+          URL="${DISPATCH_URL:-$MANUAL_URL}"
+          VOICE="${DISPATCH_VOICE:-${MANUAL_VOICE:-af_bella}}"
+          if [ -z "$URL" ]; then
+            echo "No URL provided." >&2
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "voice=$VOICE" >> "$GITHUB_OUTPUT"
+          echo "Processing: $URL (voice: $VOICE)"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # The Kokoro model (~310MB) and voices (~27MB) are gitignored and
+      # downloaded by the script. Cache them so we don't re-download each run.
+      - name: Cache Kokoro model files
+        uses: actions/cache@v4
+        with:
+          path: |
+            kokoro-v1.0.onnx
+            voices-v1.0.bin
+          key: kokoro-model-v1.0
+
+      - name: Convert article to podcast episode
+        run: |
+          python3 url_to_podcast.py "${{ steps.inputs.outputs.url }}" --voice "${{ steps.inputs.outputs.voice }}"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/ articles.csv
+          if git diff --cached --quiet; then
+            echo "No changes to commit (conversion may have failed to produce output)."
+            exit 1
+          fi
+          git commit -m "Add episode from ${{ steps.inputs.outputs.url }}"
+          git push

--- a/docs/submit.html
+++ b/docs/submit.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Submit an Article — Read Articles Podcast</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            margin: 40px auto;
+            max-width: 800px;
+            line-height: 1.6;
+            font-size: 18px;
+            color: #333;
+            background-color: #f9f9f9;
+            padding: 0 16px;
+        }
+        h1, h2 { line-height: 1.2; }
+        a { color: #007bff; }
+        label { display: block; font-weight: bold; margin-bottom: 6px; }
+        input[type="url"], select, input[type="password"] {
+            width: 100%;
+            box-sizing: border-box;
+            padding: 10px;
+            font-size: 16px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            margin-bottom: 18px;
+        }
+        button {
+            font-size: 16px;
+            padding: 10px 18px;
+            border: none;
+            border-radius: 6px;
+            background-color: #007bff;
+            color: #fff;
+            cursor: pointer;
+        }
+        button:disabled { background-color: #9bc4ef; cursor: default; }
+        button.secondary { background: none; color: #007bff; padding: 4px 0; }
+        .settings-toggle {
+            float: right;
+            font-size: 14px;
+            color: #888;
+            text-decoration: none;
+            cursor: pointer;
+        }
+        .settings-toggle:hover { color: #555; }
+        #settings {
+            display: none;
+            background: #fff;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 24px;
+            font-size: 15px;
+            line-height: 1.5;
+        }
+        #settings ol { padding-left: 20px; }
+        #settings code {
+            background: #f0f0f0;
+            padding: 1px 5px;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+        #no-token-notice {
+            background: #fff8e1;
+            border: 1px solid #ffe082;
+            border-radius: 8px;
+            padding: 16px;
+        }
+        #status {
+            margin-top: 18px;
+            padding: 12px 14px;
+            border-radius: 6px;
+            display: none;
+        }
+        #status.ok { display: block; background: #e6f4ea; border: 1px solid #b7e1c4; }
+        #status.err { display: block; background: #fdecea; border: 1px solid #f5c2bd; }
+        #status.info { display: block; background: #eef3fb; border: 1px solid #cdddf5; }
+        .muted { color: #888; font-size: 14px; }
+    </style>
+</head>
+<body>
+    <a class="settings-toggle" id="settings-toggle">⚙ Settings</a>
+    <h1>Submit an Article</h1>
+    <p>Add an article to the <a href="index.html">Read Articles Podcast</a>. It'll be converted to audio and published automatically.</p>
+
+    <!-- Settings: GitHub token. Hidden by default. -->
+    <div id="settings">
+        <h2 style="margin-top:0;">GitHub access token</h2>
+        <p>Submitting an article triggers a GitHub Action in
+           <code>deanputney/read-articles</code>. That requires a personal access
+           token, stored only in this browser (<code>localStorage</code>) — it is
+           never sent anywhere except GitHub's API.</p>
+        <ol>
+            <li>
+                Create a token:
+                <a href="https://github.com/settings/tokens/new?scopes=repo&description=read-articles%20podcast"
+                   target="_blank" rel="noopener">open GitHub token creation →</a>
+                <br>
+                <span class="muted">The link pre-selects the <code>repo</code> scope. Set an
+                expiration you're comfortable with and click <strong>Generate token</strong>.</span>
+            </li>
+            <li>Copy the token (starts with <code>ghp_</code>) and paste it below.</li>
+        </ol>
+        <label for="token">Personal access token</label>
+        <input type="password" id="token" placeholder="ghp_..." autocomplete="off">
+        <button id="save-token">Save token</button>
+        <button class="secondary" id="clear-token" style="margin-left:8px;">Remove saved token</button>
+    </div>
+
+    <!-- Shown when no token is saved. -->
+    <div id="no-token-notice">
+        Before you can submit, add a GitHub access token in
+        <a id="open-settings-link">⚙ Settings</a> (top right).
+    </div>
+
+    <!-- The submission form. Shown only when a token is saved. -->
+    <form id="submit-form" style="display:none;">
+        <label for="url">Article URL</label>
+        <input type="url" id="url" placeholder="https://example.com/some-article" required>
+
+        <label for="voice">Voice</label>
+        <select id="voice">
+            <option value="af_bella" selected>af_bella (American female)</option>
+            <option value="af_sarah">af_sarah (American female)</option>
+            <option value="af_nova">af_nova (American female)</option>
+            <option value="am_santa">am_santa (American male)</option>
+            <option value="am_adam">am_adam (American male)</option>
+            <option value="am_echo">am_echo (American male)</option>
+            <option value="bf_alice">bf_alice (British female)</option>
+            <option value="bf_emma">bf_emma (British female)</option>
+            <option value="bm_daniel">bm_daniel (British male)</option>
+            <option value="bm_george">bm_george (British male)</option>
+        </select>
+
+        <button type="submit" id="submit-btn">Submit article</button>
+        <p class="muted" style="margin-top:14px;">
+            Processing takes a few minutes. Watch progress on the
+            <a href="https://github.com/deanputney/read-articles/actions" target="_blank" rel="noopener">Actions tab</a>.
+        </p>
+    </form>
+
+    <div id="status"></div>
+
+    <script>
+        const OWNER = "deanputney";
+        const REPO = "read-articles";
+        const TOKEN_KEY = "ra_github_token";
+
+        const settings = document.getElementById("settings");
+        const settingsToggle = document.getElementById("settings-toggle");
+        const noTokenNotice = document.getElementById("no-token-notice");
+        const form = document.getElementById("submit-form");
+        const tokenInput = document.getElementById("token");
+        const statusEl = document.getElementById("status");
+
+        function getToken() {
+            return localStorage.getItem(TOKEN_KEY);
+        }
+
+        function setStatus(msg, kind) {
+            statusEl.textContent = msg;
+            statusEl.className = kind || "";
+        }
+
+        // Reflect whether a token is present: show the form, hide the notice.
+        function refreshTokenState() {
+            const hasToken = !!getToken();
+            form.style.display = hasToken ? "block" : "none";
+            noTokenNotice.style.display = hasToken ? "none" : "block";
+            if (hasToken && tokenInput.value === "") {
+                tokenInput.placeholder = "•••••••• (saved)";
+            }
+        }
+
+        settingsToggle.addEventListener("click", () => {
+            settings.style.display = settings.style.display === "block" ? "none" : "block";
+        });
+        document.getElementById("open-settings-link").addEventListener("click", () => {
+            settings.style.display = "block";
+            settings.scrollIntoView({ behavior: "smooth" });
+        });
+
+        document.getElementById("save-token").addEventListener("click", () => {
+            const val = tokenInput.value.trim();
+            if (!val) { setStatus("Enter a token first.", "err"); return; }
+            localStorage.setItem(TOKEN_KEY, val);
+            tokenInput.value = "";
+            setStatus("Token saved in this browser.", "ok");
+            refreshTokenState();
+        });
+
+        document.getElementById("clear-token").addEventListener("click", () => {
+            localStorage.removeItem(TOKEN_KEY);
+            tokenInput.value = "";
+            tokenInput.placeholder = "ghp_...";
+            setStatus("Saved token removed.", "info");
+            refreshTokenState();
+        });
+
+        form.addEventListener("submit", async (e) => {
+            e.preventDefault();
+            const token = getToken();
+            if (!token) { setStatus("No token saved — add one in Settings.", "err"); return; }
+
+            const url = document.getElementById("url").value.trim();
+            const voice = document.getElementById("voice").value;
+            const btn = document.getElementById("submit-btn");
+
+            btn.disabled = true;
+            setStatus("Sending…", "info");
+
+            try {
+                const resp = await fetch(
+                    `https://api.github.com/repos/${OWNER}/${REPO}/dispatches`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "Accept": "application/vnd.github+json",
+                            "Authorization": `Bearer ${token}`,
+                            "X-GitHub-Api-Version": "2022-11-28"
+                        },
+                        body: JSON.stringify({
+                            event_type: "new-article",
+                            client_payload: { url, voice }
+                        })
+                    }
+                );
+
+                if (resp.status === 204) {
+                    setStatus("Submitted! The Action is running — check the Actions tab in a few minutes.", "ok");
+                    form.reset();
+                } else if (resp.status === 401 || resp.status === 403) {
+                    setStatus("GitHub rejected the token (401/403). Check it has the 'repo' scope and hasn't expired — update it in Settings.", "err");
+                } else if (resp.status === 404) {
+                    setStatus("Repository not found (404). The token may lack access to this repo.", "err");
+                } else {
+                    let detail = "";
+                    try { detail = (await resp.json()).message || ""; } catch (_) {}
+                    setStatus(`Unexpected response ${resp.status}. ${detail}`, "err");
+                }
+            } catch (err) {
+                setStatus(`Request failed: ${err.message}`, "err");
+            } finally {
+                btn.disabled = false;
+            }
+        });
+
+        refreshTokenState();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a web form to submit new articles, which triggers a GitHub Action that runs `url_to_podcast.py` and commits the resulting episode back.

## What's included
- **`docs/submit.html`** — form page styled to match the site. A low-key ⚙ Settings panel holds a GitHub PAT (stored in `localStorage`, sent only to GitHub's API). The article form appears once a token is saved. Includes a direct link to GitHub's token page with the `repo` scope pre-selected, a voice dropdown, and clear error handling (401/403/404).
- **`.github/workflows/process-article.yml`** — triggers on `repository_dispatch` (`new-article`) from the form, plus `workflow_dispatch` for manual runs. Installs deps, caches the Kokoro model, runs the converter, and commits `docs/` + `articles.csv` back via the built-in `GITHUB_TOKEN`. Runs are serialized via `concurrency`.

## Note
`repository_dispatch` only fires for workflows on the **default branch**, so this must be merged to `main` before the form will work.

## Not included (optional)
AI summaries fall back to a simple description in CI since the Gemini CLI isn't installed on the runner. Can add a `GEMINI_API_KEY` secret + install step if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)